### PR TITLE
Add a standard Bootstrap navbar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,11 @@
   <link href="https://stackpath.bootstrapcdn.com/bootstrap/5.1.3/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
-  <h1>UK General Election Petition</h1>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container-fluid">
+      <a class="navbar-brand" href="#">UK General Election Petition</a>
+    </div>
+  </nav>
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/5.1.3/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes #3

Add a standard Bootstrap navbar with the site title

* Add a Bootstrap navbar with the site title "UK General Election Petition" within the `<body>` tag
* Replace the existing `<h1>` tag with the new navbar
* Include Bootstrap CSS and JS files in the `docs/index.html` file

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/4?shareId=18e2107e-46f5-489f-ae89-10e4e2af0526).