### PR TITLE
Stick the footer to the bottom of the browser window and center the text

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,7 +14,7 @@
       <a class="navbar-brand" href="#">UK General Election Petition</a>
     </div>
   </nav>
-  <footer class="footer bg-light">
+  <footer class="footer bg-light" style="position: fixed; bottom: 0; width: 100%; text-align: center;">
     <div class="container">
       <p>Made by <a href="https://links.davecross.co.uk/">Dave Cross</a> / Code on <a href="https://github.com/davorg/ge-petition">GitHub</a></p>
     </div>


### PR DESCRIPTION
Fixes #7

Stick the footer to the bottom of the browser window and center the text.

* Modify `docs/index.html` to add inline styles to the `footer` class.
  - Add `position: fixed; bottom: 0; width: 100%;` to stick the footer to the bottom of the browser window.
  - Add `text-align: center;` to center the text within the footer.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/8?shareId=f97ad700-651f-4b6d-800e-3dc1d2a9feb6).