### PR TITLE
Add Bootstrap container and row divs to contain the content

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,11 @@
       <a class="navbar-brand" href="#">UK General Election Petition</a>
     </div>
   </nav>
+  <div class="container">
+    <div class="row">
+      <!-- Main content goes here -->
+    </div>
+  </div>
   <footer class="footer bg-light" style="position: fixed; bottom: 0; width: 100%; text-align: center;">
     <div class="container">
       <p>Made by <a href="https://links.davecross.co.uk/">Dave Cross</a> / Code on <a href="https://github.com/davorg/ge-petition">GitHub</a></p>


### PR DESCRIPTION
Fixes #9

Add Bootstrap `container` and `row` divs to contain the main content

* Add a `div.container` inside the `body` tag to contain the main content
* Add a `div.row` inside the `div.container` to contain the main content
* Ensure the `nav` and `footer` are outside of these new `div`s

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/10?shareId=fa4f1900-b982-4672-a62d-fc73579ebd23).