### PR TITLE
Display the data in tables, not lists

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,15 +20,60 @@
     </div>
     <div class="row">
       <h2>Signatures by constituency</h2>
-      <ul id="signatures-by-constituency"></ul>
+      <table class="table table-striped" id="signatures-by-constituency">
+        <thead>
+          <tr>
+            <th>Constituency</th>
+            <th>Signature Count</th>
+          </tr>
+        </thead>
+        <tbody>
+        </tbody>
+        <tfoot>
+          <tr>
+            <th>Total</th>
+            <th id="total-signatures-by-constituency"></th>
+          </tr>
+        </tfoot>
+      </table>
     </div>
     <div class="row">
       <h2>Signatures by country</h2>
-      <ul id="signatures-by-country"></ul>
+      <table class="table table-striped" id="signatures-by-country">
+        <thead>
+          <tr>
+            <th>Country</th>
+            <th>Signature Count</th>
+          </tr>
+        </thead>
+        <tbody>
+        </tbody>
+        <tfoot>
+          <tr>
+            <th>Total</th>
+            <th id="total-signatures-by-country"></th>
+          </tr>
+        </tfoot>
+      </table>
     </div>
     <div class="row">
       <h2>UK vs non-UK signatures</h2>
-      <ul id="uk-vs-non-uk-signatures"></ul>
+      <table class="table table-striped" id="uk-vs-non-uk-signatures">
+        <thead>
+          <tr>
+            <th>Region</th>
+            <th>Signature Count</th>
+          </tr>
+        </thead>
+        <tbody>
+        </tbody>
+        <tfoot>
+          <tr>
+            <th>Total</th>
+            <th id="total-uk-vs-non-uk-signatures"></th>
+          </tr>
+        </tfoot>
+      </table>
     </div>
   </div>
   <footer class="footer bg-light" style="position: fixed; bottom: 0; width: 100%; text-align: center;">
@@ -46,19 +91,35 @@
         const signaturesByConstituency = data.data.attributes.signatures_by_constituency;
         const signaturesByCountry = data.data.attributes.signatures_by_country;
 
-        const constituencyList = document.getElementById('signatures-by-constituency');
+        const constituencyTableBody = document.getElementById('signatures-by-constituency').getElementsByTagName('tbody')[0];
+        let totalSignaturesByConstituency = 0;
         signaturesByConstituency.forEach(item => {
-          const listItem = document.createElement('li');
-          listItem.textContent = `${item.name}: ${item.signature_count}`;
-          constituencyList.appendChild(listItem);
+          const row = document.createElement('tr');
+          const nameCell = document.createElement('td');
+          const countCell = document.createElement('td');
+          nameCell.textContent = item.name;
+          countCell.textContent = item.signature_count;
+          row.appendChild(nameCell);
+          row.appendChild(countCell);
+          constituencyTableBody.appendChild(row);
+          totalSignaturesByConstituency += item.signature_count;
         });
+        document.getElementById('total-signatures-by-constituency').textContent = totalSignaturesByConstituency;
 
-        const countryList = document.getElementById('signatures-by-country');
+        const countryTableBody = document.getElementById('signatures-by-country').getElementsByTagName('tbody')[0];
+        let totalSignaturesByCountry = 0;
         signaturesByCountry.forEach(item => {
-          const listItem = document.createElement('li');
-          listItem.textContent = `${item.name}: ${item.signature_count}`;
-          countryList.appendChild(listItem);
+          const row = document.createElement('tr');
+          const nameCell = document.createElement('td');
+          const countCell = document.createElement('td');
+          nameCell.textContent = item.name;
+          countCell.textContent = item.signature_count;
+          row.appendChild(nameCell);
+          row.appendChild(countCell);
+          countryTableBody.appendChild(row);
+          totalSignaturesByCountry += item.signature_count;
         });
+        document.getElementById('total-signatures-by-country').textContent = totalSignaturesByCountry;
 
         const ukSignatures = signaturesByCountry.find(item => item.code === 'GB').signature_count;
         const nonUkSignatures = signaturesByCountry.reduce((acc, item) => {
@@ -68,14 +129,26 @@
           return acc;
         }, 0);
 
-        const ukVsNonUkList = document.getElementById('uk-vs-non-uk-signatures');
-        const ukListItem = document.createElement('li');
-        ukListItem.textContent = `UK: ${ukSignatures}`;
-        ukVsNonUkList.appendChild(ukListItem);
+        const ukVsNonUkTableBody = document.getElementById('uk-vs-non-uk-signatures').getElementsByTagName('tbody')[0];
+        const ukRow = document.createElement('tr');
+        const ukNameCell = document.createElement('td');
+        const ukCountCell = document.createElement('td');
+        ukNameCell.textContent = 'UK';
+        ukCountCell.textContent = ukSignatures;
+        ukRow.appendChild(ukNameCell);
+        ukRow.appendChild(ukCountCell);
+        ukVsNonUkTableBody.appendChild(ukRow);
 
-        const nonUkListItem = document.createElement('li');
-        nonUkListItem.textContent = `Non-UK: ${nonUkSignatures}`;
-        ukVsNonUkList.appendChild(nonUkListItem);
+        const nonUkRow = document.createElement('tr');
+        const nonUkNameCell = document.createElement('td');
+        const nonUkCountCell = document.createElement('td');
+        nonUkNameCell.textContent = 'Non-UK';
+        nonUkCountCell.textContent = nonUkSignatures;
+        nonUkRow.appendChild(nonUkNameCell);
+        nonUkRow.appendChild(nonUkCountCell);
+        ukVsNonUkTableBody.appendChild(nonUkRow);
+
+        document.getElementById('total-uk-vs-non-uk-signatures').textContent = ukSignatures + nonUkSignatures;
       });
   </script>
 </body>


### PR DESCRIPTION
Fixes #15

Update `docs/index.html` to display data in tables instead of lists and add a "total" row at the bottom of each table.

* Replace `<ul>` elements with `<table>` elements for displaying data.
* Add a "total" row at the bottom of each table to display the total count.
* Update JavaScript code to populate the tables instead of lists and calculate the total counts.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/16?shareId=8513141c-034c-43a3-aade-56228bdc5b7e).