### PR TITLE
Ensure the countries and constituencies are displayed in alphabetical order

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -91,6 +91,9 @@
         const signaturesByConstituency = data.data.attributes.signatures_by_constituency;
         const signaturesByCountry = data.data.attributes.signatures_by_country;
 
+        // Sort the signaturesByConstituency array alphabetically by name
+        signaturesByConstituency.sort((a, b) => a.name.localeCompare(b.name));
+
         const constituencyTableBody = document.getElementById('signatures-by-constituency').getElementsByTagName('tbody')[0];
         let totalSignaturesByConstituency = 0;
         signaturesByConstituency.forEach(item => {
@@ -105,6 +108,9 @@
           totalSignaturesByConstituency += item.signature_count;
         });
         document.getElementById('total-signatures-by-constituency').textContent = totalSignaturesByConstituency;
+
+        // Sort the signaturesByCountry array alphabetically by name
+        signaturesByCountry.sort((a, b) => a.name.localeCompare(b.name));
 
         const countryTableBody = document.getElementById('signatures-by-country').getElementsByTagName('tbody')[0];
         let totalSignaturesByCountry = 0;


### PR DESCRIPTION
Fixes #17

Sort the `signatures_by_constituency` and `signatures_by_country` arrays alphabetically by name before displaying them.

* Sort the `signatures_by_constituency` array alphabetically by `name` before displaying it.
* Sort the `signatures_by_country` array alphabetically by `name` before displaying it.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/18?shareId=78533f30-1058-4576-ad5b-77fb26b982bd).