### PR TITLE
Format numbers better

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,12 @@
   <title>UK General Election Petition</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
         integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-        crossorigin="anonymous">  
+        crossorigin="anonymous">
+  <style>
+    .right-align {
+      text-align: right;
+    }
+  </style>
 </head>
 <body>
   <nav class="navbar navbar-expand-lg navbar-light bg-light">
@@ -24,7 +29,7 @@
         <thead>
           <tr>
             <th>Constituency</th>
-            <th>Signature Count</th>
+            <th class="right-align">Signature Count</th>
           </tr>
         </thead>
         <tbody>
@@ -32,7 +37,7 @@
         <tfoot>
           <tr>
             <th>Total</th>
-            <th id="total-signatures-by-constituency"></th>
+            <th class="right-align" id="total-signatures-by-constituency"></th>
           </tr>
         </tfoot>
       </table>
@@ -43,7 +48,7 @@
         <thead>
           <tr>
             <th>Country</th>
-            <th>Signature Count</th>
+            <th class="right-align">Signature Count</th>
           </tr>
         </thead>
         <tbody>
@@ -51,7 +56,7 @@
         <tfoot>
           <tr>
             <th>Total</th>
-            <th id="total-signatures-by-country"></th>
+            <th class="right-align" id="total-signatures-by-country"></th>
           </tr>
         </tfoot>
       </table>
@@ -62,7 +67,7 @@
         <thead>
           <tr>
             <th>Region</th>
-            <th>Signature Count</th>
+            <th class="right-align">Signature Count</th>
           </tr>
         </thead>
         <tbody>
@@ -70,7 +75,7 @@
         <tfoot>
           <tr>
             <th>Total</th>
-            <th id="total-uk-vs-non-uk-signatures"></th>
+            <th class="right-align" id="total-uk-vs-non-uk-signatures"></th>
           </tr>
         </tfoot>
       </table>
@@ -85,6 +90,10 @@
           integrity="sha384-0pUGZvbkm6XF6gxjEnlmuGrJXVbNuzT9qBBavbLwCsOGabYfZo0T0to5eqruptLy"
           crossorigin="anonymous"></script>
   <script>
+    function formatNumberWithCommas(number) {
+      return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+    }
+
     fetch('700143.json')
       .then(response => response.json())
       .then(data => {
@@ -101,13 +110,14 @@
           const nameCell = document.createElement('td');
           const countCell = document.createElement('td');
           nameCell.textContent = item.name;
-          countCell.textContent = item.signature_count;
+          countCell.textContent = formatNumberWithCommas(item.signature_count);
+          countCell.classList.add('right-align');
           row.appendChild(nameCell);
           row.appendChild(countCell);
           constituencyTableBody.appendChild(row);
           totalSignaturesByConstituency += item.signature_count;
         });
-        document.getElementById('total-signatures-by-constituency').textContent = totalSignaturesByConstituency;
+        document.getElementById('total-signatures-by-constituency').textContent = formatNumberWithCommas(totalSignaturesByConstituency);
 
         // Sort the signaturesByCountry array alphabetically by name
         signaturesByCountry.sort((a, b) => a.name.localeCompare(b.name));
@@ -119,13 +129,14 @@
           const nameCell = document.createElement('td');
           const countCell = document.createElement('td');
           nameCell.textContent = item.name;
-          countCell.textContent = item.signature_count;
+          countCell.textContent = formatNumberWithCommas(item.signature_count);
+          countCell.classList.add('right-align');
           row.appendChild(nameCell);
           row.appendChild(countCell);
           countryTableBody.appendChild(row);
           totalSignaturesByCountry += item.signature_count;
         });
-        document.getElementById('total-signatures-by-country').textContent = totalSignaturesByCountry;
+        document.getElementById('total-signatures-by-country').textContent = formatNumberWithCommas(totalSignaturesByCountry);
 
         const ukSignatures = signaturesByCountry.find(item => item.code === 'GB').signature_count;
         const nonUkSignatures = signaturesByCountry.reduce((acc, item) => {
@@ -140,7 +151,8 @@
         const ukNameCell = document.createElement('td');
         const ukCountCell = document.createElement('td');
         ukNameCell.textContent = 'UK';
-        ukCountCell.textContent = ukSignatures;
+        ukCountCell.textContent = formatNumberWithCommas(ukSignatures);
+        ukCountCell.classList.add('right-align');
         ukRow.appendChild(ukNameCell);
         ukRow.appendChild(ukCountCell);
         ukVsNonUkTableBody.appendChild(ukRow);
@@ -149,12 +161,13 @@
         const nonUkNameCell = document.createElement('td');
         const nonUkCountCell = document.createElement('td');
         nonUkNameCell.textContent = 'Non-UK';
-        nonUkCountCell.textContent = nonUkSignatures;
+        nonUkCountCell.textContent = formatNumberWithCommas(nonUkSignatures);
+        nonUkCountCell.classList.add('right-align');
         nonUkRow.appendChild(nonUkNameCell);
         nonUkRow.appendChild(nonUkCountCell);
         ukVsNonUkTableBody.appendChild(nonUkRow);
 
-        document.getElementById('total-uk-vs-non-uk-signatures').textContent = ukSignatures + nonUkSignatures;
+        document.getElementById('total-uk-vs-non-uk-signatures').textContent = formatNumberWithCommas(ukSignatures + nonUkSignatures);
       });
   </script>
 </body>


### PR DESCRIPTION
Fixes #19

Format numbers in the HTML tables and right-align them.

* Add a CSS class `.right-align` to right-align numbers in table cells.
* Add a JavaScript function `formatNumberWithCommas` to format numbers with commas.
* Apply the `.right-align` class to the `th` and `td` elements containing numbers in the tables.
* Call the `formatNumberWithCommas` function to format numbers in the `td` elements and total signature counts.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/20?shareId=28a40dc3-2248-4c95-9c08-5797f5d9f275).