### PR TITLE
Make the table narrower

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,7 +25,7 @@
     </div>
     <div class="row">
       <h2>Signatures by constituency</h2>
-      <table class="table table-striped" id="signatures-by-constituency">
+      <table class="table table-striped mx-auto" style="width: 60%;" id="signatures-by-constituency">
         <thead>
           <tr>
             <th>Constituency</th>
@@ -44,7 +44,7 @@
     </div>
     <div class="row">
       <h2>Signatures by country</h2>
-      <table class="table table-striped" id="signatures-by-country">
+      <table class="table table-striped mx-auto" style="width: 60%;" id="signatures-by-country">
         <thead>
           <tr>
             <th>Country</th>
@@ -63,7 +63,7 @@
     </div>
     <div class="row">
       <h2>UK vs non-UK signatures</h2>
-      <table class="table table-striped" id="uk-vs-non-uk-signatures">
+      <table class="table table-striped mx-auto" style="width: 60%;" id="uk-vs-non-uk-signatures">
         <thead>
           <tr>
             <th>Region</th>


### PR DESCRIPTION
Fixes #21

Modify `docs/index.html` to make the table narrower and centered.

* Add `style="width: 60%;"` to the `table` elements to set the table width to 60%.
* Add `class="mx-auto"` to the `table` elements to center the table.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/22?shareId=072af8d7-5454-4266-aa88-2511792664ac).