### PR TITLE
Add padding to the bottom of the page so the fixed footer doesn't cover the data

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
     }
   </style>
 </head>
-<body>
+<body style="padding-bottom: 60px;">
   <nav class="navbar navbar-expand-lg navbar-light bg-light">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">UK General Election Petition</a>


### PR DESCRIPTION
Fixes #23

Add padding to the bottom of the page to prevent the fixed footer from covering the data

* Modify `docs/index.html` to include `padding-bottom: 60px;` in the `body` element

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/24?shareId=a88684b3-466e-4142-b225-ed297fa8ef3e).