### PR TITLE
Scrollbars on tables

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,16 @@
     .right-align {
       text-align: right;
     }
+    .scrollable-table {
+      display: block;
+      max-height: 400px; /* Adjust the height as needed */
+      overflow-y: auto;
+    }
+    .scrollable-table thead th {
+      position: sticky;
+      top: 0;
+      background: white;
+    }
   </style>
 </head>
 <body style="padding-bottom: 60px;">
@@ -25,41 +35,45 @@
     </div>
     <div class="row">
       <h2>Signatures by constituency</h2>
-      <table class="table table-striped mx-auto" style="width: 60%;" id="signatures-by-constituency">
-        <thead>
-          <tr>
-            <th>Constituency</th>
-            <th class="right-align">Signature Count</th>
-          </tr>
-        </thead>
-        <tbody>
-        </tbody>
-        <tfoot>
-          <tr>
-            <th>Total</th>
-            <th class="right-align" id="total-signatures-by-constituency"></th>
-          </tr>
-        </tfoot>
-      </table>
+      <div class="scrollable-table">
+        <table class="table table-striped mx-auto" style="width: 60%;" id="signatures-by-constituency">
+          <thead>
+            <tr>
+              <th>Constituency</th>
+              <th class="right-align">Signature Count</th>
+            </tr>
+          </thead>
+          <tbody>
+          </tbody>
+          <tfoot>
+            <tr>
+              <th>Total</th>
+              <th class="right-align" id="total-signatures-by-constituency"></th>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
     </div>
     <div class="row">
       <h2>Signatures by country</h2>
-      <table class="table table-striped mx-auto" style="width: 60%;" id="signatures-by-country">
-        <thead>
-          <tr>
-            <th>Country</th>
-            <th class="right-align">Signature Count</th>
-          </tr>
-        </thead>
-        <tbody>
-        </tbody>
-        <tfoot>
-          <tr>
-            <th>Total</th>
-            <th class="right-align" id="total-signatures-by-country"></th>
-          </tr>
-        </tfoot>
-      </table>
+      <div class="scrollable-table">
+        <table class="table table-striped mx-auto" style="width: 60%;" id="signatures-by-country">
+          <thead>
+            <tr>
+              <th>Country</th>
+              <th class="right-align">Signature Count</th>
+            </tr>
+          </thead>
+          <tbody>
+          </tbody>
+          <tfoot>
+            <tr>
+              <th>Total</th>
+              <th class="right-align" id="total-signatures-by-country"></th>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
     </div>
     <div class="row">
       <h2>UK vs non-UK signatures</h2>


### PR DESCRIPTION
Fixes #25

Add scrollbars and fixed header rows to the first two tables in `docs/index.html`.

* Add CSS to limit the height of the first two tables to 12 rows and enable scrollbars.
* Add CSS to make the header rows of the first two tables fixed.
* Wrap the first two tables in a `div` with the class `scrollable-table`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/26?shareId=6f68a9a0-acb3-4fc2-a9f5-8e44c44fefa8).