### PR TITLE
Tidy CSS

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,28 +7,9 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
         integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
         crossorigin="anonymous">
-  <style>
-    .right-align {
-      text-align: right;
-    }
-    .scrollable-table {
-      display: block;
-      max-height: 400px; /* Adjust the height as needed */
-      overflow-y: auto;
-    }
-    .scrollable-table thead th {
-      position: sticky;
-      top: 0;
-      background: white;
-    }
-    .scrollable-table tfoot th {
-      position: sticky;
-      bottom: 0;
-      background: white;
-    }
-  </style>
+  <link rel="stylesheet" href="style.css">
 </head>
-<body style="padding-bottom: 60px;">
+<body>
   <nav class="navbar navbar-expand-lg navbar-light bg-light">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">UK General Election Petition</a>
@@ -100,7 +81,7 @@
       </table>
     </div>
   </div>
-  <footer class="footer bg-light" style="position: fixed; bottom: 0; width: 100%; text-align: center;">
+  <footer class="footer bg-light">
     <div class="container">
       <p>Made by <a href="https://links.davecross.co.uk/">Dave Cross</a> / Code on <a href="https://github.com/davorg/ge-petition">GitHub</a></p>
     </div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,28 @@
+.right-align {
+  text-align: right;
+}
+
+.scrollable-table {
+  display: block;
+  max-height: 400px; /* Adjust the height as needed */
+  overflow-y: auto;
+}
+
+.scrollable-table thead th {
+  position: sticky;
+  top: 0;
+  background: white;
+}
+
+.scrollable-table tfoot th {
+  position: sticky;
+  bottom: 0;
+  background: white;
+}
+
+.footer {
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  text-align: center;
+}


### PR DESCRIPTION
Fixes #27

Move CSS from HTML file to a separate `style.css` file.

* Add `docs/style.css` with CSS styles for `.right-align`, `.scrollable-table`, `.scrollable-table thead th`, `.scrollable-table tfoot th`, and `.footer` classes.
* Remove the `<style>` tag containing CSS styles from `docs/index.html`.
* Remove the `style` attribute from the `<body>` tag in `docs/index.html`.
* Add a link to `style.css` in the `<head>` section of `docs/index.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/28?shareId=fe9d3b76-14c0-489a-8062-58f500d6e974).