### PR TITLE
Put the body padding back

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -26,3 +26,7 @@
   width: 100%;
   text-align: center;
 }
+
+body {
+  padding-bottom: 60px;
+}


### PR DESCRIPTION
Fixes #29

Add padding to the bottom of the page to prevent the footer from obscuring the end of the last table.

* Modify `docs/style.css` to include `padding-bottom: 60px;` in the `body` element.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/30?shareId=e6f3b654-98e7-4a60-8e24-51eac07f39a2).