### PR TITLE
Add scrollable table class to table elements

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -22,7 +22,7 @@
     <div class="row">
       <h2>Signatures by constituency</h2>
       <div class="table-responsive">
-        <table class="table table-striped mx-auto w-75" id="signatures-by-constituency">
+        <table class="table table-striped mx-auto w-75 scrollable-table" id="signatures-by-constituency">
           <thead>
             <tr>
               <th>Constituency</th>
@@ -43,7 +43,7 @@
     <div class="row">
       <h2>Signatures by country</h2>
       <div class="table-responsive">
-        <table class="table table-striped mx-auto w-75" id="signatures-by-country">
+        <table class="table table-striped mx-auto w-75 scrollable-table" id="signatures-by-country">
           <thead>
             <tr>
               <th>Country</th>
@@ -64,7 +64,7 @@
     <div class="row">
       <h2>UK vs non-UK signatures</h2>
       <div class="table-responsive">
-        <table class="table table-striped mx-auto w-75" id="uk-vs-non-uk-signatures">
+        <table class="table table-striped mx-auto w-75 scrollable-table" id="uk-vs-non-uk-signatures">
           <thead>
             <tr>
               <th>Region</th>


### PR DESCRIPTION
Fixes #35

Add the `scrollable-table` class to the table elements in `docs/index.html`.

* Apply the `scrollable-table` class to the `table` elements with IDs `signatures-by-constituency`, `signatures-by-country`, and `uk-vs-non-uk-signatures`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/36?shareId=1a93681d-8cbb-48b7-ad53-60a7cea091b1).