### PR TITLE
Fix scrollbars on tbody instead of containing div

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -22,14 +22,14 @@
     <div class="row">
       <h2>Signatures by constituency</h2>
       <div class="table-responsive">
-        <table class="table table-striped mx-auto w-75 scrollable-table" id="signatures-by-constituency">
+        <table class="table table-striped mx-auto w-75" id="signatures-by-constituency">
           <thead>
             <tr>
               <th>Constituency</th>
               <th class="text-end">Signature Count</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody class="scrollable-table">
           </tbody>
           <tfoot>
             <tr>
@@ -43,14 +43,14 @@
     <div class="row">
       <h2>Signatures by country</h2>
       <div class="table-responsive">
-        <table class="table table-striped mx-auto w-75 scrollable-table" id="signatures-by-country">
+        <table class="table table-striped mx-auto w-75" id="signatures-by-country">
           <thead>
             <tr>
               <th>Country</th>
               <th class="text-end">Signature Count</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody class="scrollable-table">
           </tbody>
           <tfoot>
             <tr>
@@ -64,14 +64,14 @@
     <div class="row">
       <h2>UK vs non-UK signatures</h2>
       <div class="table-responsive">
-        <table class="table table-striped mx-auto w-75 scrollable-table" id="uk-vs-non-uk-signatures">
+        <table class="table table-striped mx-auto w-75" id="uk-vs-non-uk-signatures">
           <thead>
             <tr>
               <th>Region</th>
               <th class="text-end">Signature Count</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody class="scrollable-table">
           </tbody>
           <tfoot>
             <tr>


### PR DESCRIPTION
Fixes #37

Move the `scrollable-table` class from the `div` elements to the `tbody` elements in `docs/index.html`.

* Update the `scrollable-table` class in `docs/style.css` to apply styles to `tbody` instead of `div`.
* Ensure the `max-height` and `overflow-y` properties are applied to `tbody` in `docs/style.css`.
* Remove the `scrollable-table` class from the `div` elements in `docs/index.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/38?shareId=ed7f5470-5576-4b5f-bcab-61c922d9dbc0).