### PR TITLE
Use Bootstrap grid to position the tables

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,65 +21,77 @@
     </div>
     <div class="row">
       <h2>Signatures by constituency</h2>
-      <div class="table-responsive">
-        <table class="table table-striped scrollable-table mx-auto w-75" id="signatures-by-constituency">
-          <thead>
-            <tr>
-              <th>Constituency</th>
-              <th class="text-end">Signature Count</th>
-            </tr>
-          </thead>
-          <tbody>
-          </tbody>
-          <tfoot>
-            <tr>
-              <th>Total</th>
-              <th class="text-end" id="total-signatures-by-constituency"></th>
-            </tr>
-          </tfoot>
-        </table>
+      <div class="row">
+        <div class="col-md-6 offset-md-3">
+          <div class="table-responsive">
+            <table class="table table-striped scrollable-table" id="signatures-by-constituency">
+              <thead>
+                <tr>
+                  <th>Constituency</th>
+                  <th class="text-end">Signature Count</th>
+                </tr>
+              </thead>
+              <tbody>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <th>Total</th>
+                  <th class="text-end" id="total-signatures-by-constituency"></th>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </div>
       </div>
     </div>
     <div class="row">
       <h2>Signatures by country</h2>
-      <div class="table-responsive">
-        <table class="table table-striped scrollable-table mx-auto w-75" id="signatures-by-country">
-          <thead>
-            <tr>
-              <th>Country</th>
-              <th class="text-end">Signature Count</th>
-            </tr>
-          </thead>
-          <tbody>
-          </tbody>
-          <tfoot>
-            <tr>
-              <th>Total</th>
-              <th class="text-end" id="total-signatures-by-country"></th>
-            </tr>
-          </tfoot>
-        </table>
+      <div class="row">
+        <div class="col-md-6 offset-md-3">
+          <div class="table-responsive">
+            <table class="table table-striped scrollable-table" id="signatures-by-country">
+              <thead>
+                <tr>
+                  <th>Country</th>
+                  <th class="text-end">Signature Count</th>
+                </tr>
+              </thead>
+              <tbody>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <th>Total</th>
+                  <th class="text-end" id="total-signatures-by-country"></th>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </div>
       </div>
     </div>
     <div class="row">
       <h2>UK vs non-UK signatures</h2>
-      <div class="table-responsive">
-        <table class="table table-striped scrollable-table mx-auto w-75" id="uk-vs-non-uk-signatures">
-          <thead>
-            <tr>
-              <th>Region</th>
-              <th class="text-end">Signature Count</th>
-            </tr>
-          </thead>
-          <tbody>
-          </tbody>
-          <tfoot>
-            <tr>
-              <th>Total</th>
-              <th class="text-end" id="total-uk-vs-non-uk-signatures"></th>
-            </tr>
-          </tfoot>
-        </table>
+      <div class="row">
+        <div class="col-md-6 offset-md-3">
+          <div class="table-responsive">
+            <table class="table table-striped scrollable-table" id="uk-vs-non-uk-signatures">
+              <thead>
+                <tr>
+                  <th>Region</th>
+                  <th class="text-end">Signature Count</th>
+                </tr>
+              </thead>
+              <tbody>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <th>Total</th>
+                  <th class="text-end" id="total-uk-vs-non-uk-signatures"></th>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #39

Wrap the tables in `docs/index.html` with Bootstrap grid classes to position them with empty 3-column spaces on either side.

* Wrap each table in a `div` with the `col-md-6 offset-md-3` classes within a `div` with the `row` class.
* Remove the `mx-auto w-75` classes from each table.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/40?shareId=aa42ba19-04b2-48b1-950e-62563ce96f44).