### PR TITLE
Add a GitHub Actions workflow

### DIFF
--- a/.github/workflows/update-petition-data.yml
+++ b/.github/workflows/update-petition-data.yml
@@ -1,0 +1,41 @@
+name: Update Petition Data
+
+on:
+  schedule:
+    - cron: '15,45 * * * *'
+
+jobs:
+  update-data:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Download petition data
+      run: curl -o docs/700143.json https://petition.parliament.uk/petitions/700143.json
+
+    - name: Update footer with timestamps
+      run: |
+        now=$(date -u +"%Y-%m-%d %H:%M")
+        next_update=$(date -u -d "+30 minutes" +"%Y-%m-%d %H:%M")
+        sed -i "s/Last data update: .*/Last data update: $now \/ Next data update: $next_update/" docs/index.html
+
+    - name: Commit changes
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git add docs/700143.json docs/index.html
+        git commit -m "Update petition data and timestamps"
+
+    - name: Push changes
+      uses: ad-m/github-push-action@v0.6.0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: main
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs

--- a/docs/index.html
+++ b/docs/index.html
@@ -98,6 +98,7 @@
   <footer class="footer bg-light text-center py-3">
     <div class="container">
       <p>Made by <a href="https://links.davecross.co.uk/">Dave Cross</a> / Code on <a href="https://github.com/davorg/ge-petition">GitHub</a></p>
+      <p id="data-update-info">Last data update: YYYY-MM-DD HH:MM / Next data update: YYYY-MM-DD HH:MM</p>
     </div>
   </footer>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.min.js"

--- a/docs/script.js
+++ b/docs/script.js
@@ -2,6 +2,13 @@ function formatNumberWithCommas(number) {
   return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
 
+function updateFooterWithTimestamps() {
+  const now = new Date();
+  const lastUpdate = now.toISOString().slice(0, 16).replace('T', ' ');
+  const nextUpdate = new Date(now.getTime() + 30 * 60000).toISOString().slice(0, 16).replace('T', ' ');
+  document.getElementById('data-update-info').textContent = `Last data update: ${lastUpdate} / Next data update: ${nextUpdate}`;
+}
+
 fetch('700143.json')
   .then(response => response.json())
   .then(data => {
@@ -76,4 +83,6 @@ fetch('700143.json')
     ukVsNonUkTableBody.appendChild(nonUkRow);
 
     document.getElementById('total-uk-vs-non-uk-signatures').textContent = formatNumberWithCommas(ukSignatures + nonUkSignatures);
+
+    updateFooterWithTimestamps();
   });


### PR DESCRIPTION
Fixes #41

Add a GitHub Actions workflow to update petition data and timestamps.

* **GitHub Actions Workflow**: Create `update-petition-data.yml` to run at 15 and 45 minutes past every hour, download the JSON file, update the footer in `docs/index.html`, commit changes, and redeploy the site to GitHub Pages.
* **Footer Update**: Modify `docs/index.html` to include a new paragraph in the footer displaying "Last data update: YYYY-MM-DD HH:MM / Next data update: YYYY-MM-DD HH:MM".
* **JavaScript Function**: Add a function in `docs/script.js` to update the footer with the last and next data update times and call this function after fetching the JSON data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/davorg/ge-petition/pull/42?shareId=b12bf766-fccc-43c7-adb2-47d563f4bf9d).